### PR TITLE
Fixing ModelWithCRFLossDSCLoss when sparse_target=False

### DIFF
--- a/tf2crf/model_wrapper.py
+++ b/tf2crf/model_wrapper.py
@@ -148,6 +148,10 @@ class ModelWithCRFLossDSCLoss(tf.keras.Model):
 
     def test_step(self, data):
         x, y, sample_weight = unpack_data(data)
+        if self.sparse_target:
+            assert len(y.shape) == 2
+        else:
+            y = tf.argmax(y, axis=-1)
         viterbi_sequence, sequence_length, crf_loss, ds_loss = self.compute_loss(x, y, sample_weight, training=True)
         loss = crf_loss + ds_loss + tf.cast(tf.reduce_sum(self.losses), crf_loss.dtype)
         self.loss_tracker.update_state(loss)


### PR DESCRIPTION
The following code line is **missing** when `sparse_target=False`, in the **test_step** method of the **ModelWithCRFLossDSCLoss** class in **model_wrapper** module.
`y = tf.argmax(y, axis=-1)`